### PR TITLE
feat: make eating an act + auto-sit at anchor

### DIFF
--- a/ninjamagic/reach.py
+++ b/ninjamagic/reach.py
@@ -1,5 +1,5 @@
 from collections.abc import Callable, Generator
-from typing import Any
+from typing import Any, TypeVar
 
 import esper
 
@@ -7,6 +7,15 @@ from ninjamagic.component import EntityId, Noun, Transform, transform
 from ninjamagic.util import VIEW_STRIDE_H, VIEW_STRIDE_W
 
 Selector = Callable[[Transform, Transform], bool]
+T = TypeVar("T")
+
+
+def find_at(position: Transform, component: type[T]) -> tuple[EntityId, T] | None:
+    """Find first entity at position with given component."""
+    for eid, (tf, cmp) in esper.get_components(Transform, component):
+        if tf == position:
+            return eid, cmp
+    return None
 
 
 def adjacent(this: Transform, that: Transform) -> bool:


### PR DESCRIPTION
## Summary
- Eating now queues as an act with delay (like forage, cook)
- Shows "{0} {0:begins} to eat..." message while action is in progress
- If there's an anchor in the same cell and you're not sitting at it, you automatically sit at it before eating

## Test plan
- [x] All existing tests pass (304 passed)
- [x] No critical lint errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)