### PR TITLE
feat: block health regen during active combat

### DIFF
--- a/ninjamagic/component.py
+++ b/ninjamagic/component.py
@@ -8,6 +8,7 @@ import esper
 from fastapi import WebSocket
 
 from ninjamagic import util
+from ninjamagic.config import settings
 from ninjamagic.nightclock import NightClock
 from ninjamagic.util import (
     TILE_STRIDE_H,
@@ -16,6 +17,7 @@ from ninjamagic.util import (
     Num,
     Pronoun,
     Pronouns,
+    get_looptime,
 )
 
 Biomes = Literal["cave", "forest"]
@@ -167,6 +169,9 @@ class FightTimer:
     last_atk_proc: Looptime
     last_def_proc: Looptime
     last_refresh: Looptime
+
+    def is_active(self) -> bool:
+        return get_looptime() - self.last_refresh < settings.fight_timer_len
 
 
 Gas = NewType("Gas", dict[tuple[int, int], float])

--- a/ninjamagic/config.py
+++ b/ninjamagic/config.py
@@ -28,6 +28,7 @@ class Settings(BaseSettings):
     stun_len: float = 5.0
 
     base_proc_odds: float = 0.10
+    fight_timer_len: float = 10.0
 
     model_config = SettingsConfigDict(
         env_nested_delimiter="__", env_file="ninjamagic.env"

--- a/ninjamagic/regen.py
+++ b/ninjamagic/regen.py
@@ -1,7 +1,7 @@
 import esper
 
 from ninjamagic import bus
-from ninjamagic.component import Health, Stance
+from ninjamagic.component import FightTimer, Health, Stance
 from ninjamagic.config import settings
 from ninjamagic.util import Looptime
 
@@ -13,6 +13,8 @@ def process(now: Looptime):
     while now >= next_call:
         for eid, (health, stance) in esper.get_components(Health, Stance):
             if health.condition != "normal":
+                continue
+            if (ft := esper.try_component(eid, FightTimer)) and ft.is_active():
                 continue
             if stance.cur == "lying prone":
                 bus.pulse(


### PR DESCRIPTION
## Summary
- Prevents health regeneration while FightTimer is active
- Adds `is_active()` method to FightTimer that checks if `last_refresh` is within `fight_timer_len` seconds
- Adds `fight_timer_len` config setting (default 10s)

## Test plan
- [ ] Start fight, get hurt, lie down - no regen while fighting
- [ ] Wait 10s after combat ends - regen resumes

🤖 Generated with [Claude Code](https://claude.com/claude-code)