### PR TITLE
feat: add anchor rank/tnl with GrowAnchor signal

### DIFF
--- a/ninjamagic/bus.py
+++ b/ninjamagic/bus.py
@@ -85,6 +85,14 @@ class Learn(Signal):
 
 
 @signal(frozen=True, slots=True, kw_only=True)
+class GrowAnchor(Signal):
+    "Contribute to an anchor's growth."
+
+    anchor: EntityId
+    amount: float
+
+
+@signal(frozen=True, slots=True, kw_only=True)
 class AbsorbRestExp(Signal):
     "An entity absorbed their rest exp."
 

--- a/ninjamagic/component.py
+++ b/ninjamagic/component.py
@@ -21,9 +21,7 @@ from ninjamagic.util import (
 Biomes = Literal["cave", "forest"]
 Conditions = Literal["normal", "unconscious", "in shock", "dead"]
 Stances = Literal["standing", "kneeling", "sitting", "lying prone"]
-ProcVerb = Literal[
-    "slash", "slice", "stab", "thrust", "punch", "dodge", "block", "shield", "parry"
-]
+ProcVerb = Literal["slash", "slice", "stab", "thrust", "punch", "dodge", "block", "shield", "parry"]
 T = TypeVar("T")
 EntityId = int
 MAX_HEALTH = 100.0
@@ -146,7 +144,11 @@ class LastAnchorRest:
 
 @component(slots=True, kw_only=True)
 class Anchor:
-    """The entity is an anchor."""
+    """Light against the darkness."""
+
+    rank: int = 1
+    tnl: float = 0
+    rankup_echo: str = ""
 
 
 @component(slots=True, kw_only=True)

--- a/ninjamagic/component.py
+++ b/ninjamagic/component.py
@@ -148,7 +148,7 @@ class Anchor:
 
     rank: int = 1
     tnl: float = 0
-    rankup_echo: str = ""
+    rankup_echo: str
 
 
 @component(slots=True, kw_only=True)

--- a/ninjamagic/experience.py
+++ b/ninjamagic/experience.py
@@ -3,8 +3,8 @@ from functools import partial
 
 import esper
 
-from ninjamagic import bus, util
-from ninjamagic.component import Ate, EntityId, RestExp, Skills, skills
+from ninjamagic import bus, reach, story, util
+from ninjamagic.component import Anchor, Ate, EntityId, RestExp, Skills, skills
 from ninjamagic.util import Trial
 
 log = logging.getLogger(__name__)
@@ -85,3 +85,16 @@ def process():
                 to=sig.source, name=skill.name, rank=skill.rank, tnl=skill.tnl
             )
         )
+
+    for sig in bus.iter(bus.GrowAnchor):
+        anchor = esper.try_component(sig.anchor, Anchor)
+        if not anchor:
+            continue
+        anchor.tnl += sig.amount
+        while anchor.tnl >= 1.0:
+            anchor.rank += 1
+            anchor.tnl -= 1.0
+            anchor.tnl *= RANKUP_FALLOFF
+            log.info("anchor_rankup: anchor=%s rank=%s", sig.anchor, anchor.rank)
+            if anchor.rankup_echo:
+                story.echo(anchor.rankup_echo, sig.anchor, range=reach.visible)

--- a/ninjamagic/experience.py
+++ b/ninjamagic/experience.py
@@ -94,5 +94,4 @@ def process():
             anchor.tnl -= 1.0
             anchor.tnl *= RANKUP_FALLOFF
             log.info("anchor_rankup: anchor=%s rank=%s", sig.anchor, anchor.rank)
-            if anchor.rankup_echo:
-                story.echo(anchor.rankup_echo, sig.anchor, range=reach.visible)
+            story.echo(anchor.rankup_echo, sig.anchor, range=reach.visible)

--- a/ninjamagic/experience.py
+++ b/ninjamagic/experience.py
@@ -87,9 +87,7 @@ def process():
         )
 
     for sig in bus.iter(bus.GrowAnchor):
-        anchor = esper.try_component(sig.anchor, Anchor)
-        if not anchor:
-            continue
+        anchor = esper.component_for_entity(sig.anchor, Anchor)
         anchor.tnl += sig.amount
         while anchor.tnl >= 1.0:
             anchor.rank += 1

--- a/ninjamagic/survive.py
+++ b/ninjamagic/survive.py
@@ -211,6 +211,10 @@ def process_rest() -> None:
         if at_anchor:
             weariness_factor = 1.0
             esper.add_component(eid, LastAnchorRest())
+            anchor = esper.component_for_entity(prop, Anchor)
+            mult = contest(survival_rank, anchor.rank, tag="anchor_growth")
+            award = Trial.get_award(mult=mult)
+            bus.pulse(bus.GrowAnchor(anchor=prop, amount=award))
             rested = True
         else:
             last_rest = esper.try_component(eid, LastAnchorRest)
@@ -227,20 +231,14 @@ def process_rest() -> None:
                 mult = contest(rest_rank, hostility)
                 rested = Trial.check(mult=mult)
                 bus.pulse(
-                    bus.Learn(
-                        source=eid, teacher=loc.map_id, skill=skill.survival, mult=mult
-                    )
+                    bus.Learn(source=eid, teacher=loc.map_id, skill=skill.survival, mult=mult)
                 )
 
         # last ditch effort
         if not rested:
             mult = contest(survival_rank * weariness_factor, hostility)
             rested = Trial.check(mult=mult, difficulty=Trial.INFEASIBLE)
-            bus.pulse(
-                bus.Learn(
-                    source=eid, teacher=loc.map_id, skill=skill.survival, mult=mult
-                )
-            )
+            bus.pulse(bus.Learn(source=eid, teacher=loc.map_id, skill=skill.survival, mult=mult))
 
         if rested:
             bus.pulse(
@@ -258,8 +256,6 @@ def process_rest() -> None:
             case True, True:
                 story.echo("{0} {0:rests}.", eid)
             case True, False:
-                story.echo(
-                    "{0} {0:rests} in fits, woken twice by an empty stomach.", eid
-                )
+                story.echo("{0} {0:rests} in fits, woken twice by an empty stomach.", eid)
             case _:
                 story.echo("{0} {0:rests}, but not well.", eid)

--- a/ninjamagic/world/state.py
+++ b/ninjamagic/world/state.py
@@ -104,7 +104,7 @@ def build_hub(map_id: EntityId, chips: Chips):
 
     bonfire = esper.create_entity(
         Transform(map_id=map_id, y=9, x=4),
-        Anchor(),
+        Anchor(rankup_echo="{0:def} {0:flares}, casting back the darkness."),
         ProvidesHeat(),
         ProvidesLight(),
         Noun(value="bonfire", pronoun=Pronouns.IT),


### PR DESCRIPTION
## Summary
- `Anchor.rank` (default 1) - anchor strength
- `Anchor.tnl` (default 0) - accumulates growth toward next rank
- `GrowAnchor(anchor, amount)` signal processed in experience.py
- Ranks up when tnl >= 1.0

Kindling system will pulse `GrowAnchor` when player puts ember in bonfire.

## Test plan
- [x] Existing code still works
- [ ] Future: test kindling → GrowAnchor flow

🤖 Generated with [Claude Code](https://claude.com/claude-code)