### PR TITLE
feat: add help command

### DIFF
--- a/ninjamagic/commands.py
+++ b/ninjamagic/commands.py
@@ -833,35 +833,31 @@ class Recall(Command):
         return OK
 
 
-HELP_TEXTS: dict[str, str] = {
-    "look": "Look at something or in a container.\n"
-    "Usage: look at <target>\n       look in <container>",
-    "say": "Say something out loud.\n"
-    "Usage: say <message>\n       '<message> (shortcut)",
-    "emote": "Perform an action/emote.\nUsage: emote <action>",
-    "attack": "Attack a target.\nUsage: attack <target>",
-    "stand": "Stand up.\nUsage: stand [beside <target>]",
-    "sit": "Sit down.\nUsage: sit [beside <target>]",
-    "lie": "Lie down.\nUsage: lie [beside <target>]",
-    "rest": "Rest (lie down).\nUsage: rest [beside <target>]",
-    "kneel": "Kneel down.\nUsage: kneel [beside <target>]",
-    "block": "Block incoming attacks.\nUsage: block",
-    "recall": "Return to your bind point.\nUsage: recall",
-    "inventory": "View your inventory.\nUsage: inventory",
-    "get": "Pick up an item.\n"
-    "Usage: get <item>\n       get <item> from <container>",
-    "put": "Put an item somewhere.\nUsage: put <item> in <container>",
-    "stow": "Stow an item in a container.\nUsage: stow <item> [in <container>]",
-    "drop": "Drop an item.\nUsage: drop <item>",
-    "wear": "Wear an item.\nUsage: wear <item>",
-    "remove": "Remove worn item.\nUsage: remove <item>",
-    "swap": "Swap items between hands.\nUsage: swap",
-    "forage": "Forage for items.\nUsage: forage",
-    "eat": "Eat food.\nUsage: eat <food>",
-    "time": "Check the current time.\nUsage: time",
-    "help": "Get help for a command.\nUsage: help <command>\n\n"
-    "Type 'commands' to see available commands.",
-    "commands": "List available commands.\nUsage: commands",
+HELP_TEXTS: dict[str, tuple[str, str]] = {
+    "look": ("look at <target>\nlook in <container>", "Look at something or in a container."),
+    "say": ("say <message>\n'<message>", "Say something out loud."),
+    "emote": ("emote <action>", "Perform an action/emote."),
+    "attack": ("attack <target>", "Attack a target."),
+    "stand": ("stand [beside <target>]", "Stand up."),
+    "sit": ("sit [beside <target>]", "Sit down."),
+    "lie": ("lie [beside <target>]", "Lie down."),
+    "rest": ("rest [beside <target>]", "Rest (lie down)."),
+    "kneel": ("kneel [beside <target>]", "Kneel down."),
+    "block": ("block", "Block incoming attacks."),
+    "recall": ("recall", "Return to your bind point."),
+    "inventory": ("inventory", "View your inventory."),
+    "get": ("get <item>\nget <item> from <container>", "Pick up an item."),
+    "put": ("put <item> in <container>", "Put an item somewhere."),
+    "stow": ("stow <item> [in <container>]", "Stow an item in a container."),
+    "drop": ("drop <item>", "Drop an item."),
+    "wear": ("wear <item>", "Wear an item."),
+    "remove": ("remove <item>", "Remove worn item."),
+    "swap": ("swap", "Swap items between hands."),
+    "forage": ("forage", "Forage for items."),
+    "eat": ("eat <food>", "Eat food."),
+    "time": ("time", "Check the current time."),
+    "help": ("help <command>", "Get help for a command. Type 'commands' for list."),
+    "commands": ("commands", "List available commands."),
 }
 
 
@@ -901,17 +897,13 @@ class Help(Command):
             )
             return OK
 
-        parts = [f"Command: {cmd_match.text}"]
-        if cmd_match.requires_standing:
-            parts.append("Requires: standing")
-        if cmd_match.requires_healthy:
-            parts.append("Requires: healthy")
+        if help_entry := HELP_TEXTS.get(cmd_match.text):
+            usage, desc = help_entry
+            text = f"{usage}\n\n  {desc}"
+        else:
+            text = f"No help available for '{cmd_match.text}'."
 
-        if help_text := HELP_TEXTS.get(cmd_match.text):
-            parts.append("")
-            parts.append(help_text)
-
-        bus.pulse(bus.Outbound(to=root.source, text="\n".join(parts)))
+        bus.pulse(bus.Outbound(to=root.source, text=text))
         return OK
 
 

--- a/ninjamagic/commands.py
+++ b/ninjamagic/commands.py
@@ -843,7 +843,7 @@ HELP_TEXTS: dict[str, tuple[str, str]] = {
     "lie": ("lie [beside <target>]", "Lie down."),
     "rest": ("rest [beside <target>]", "Rest (lie down)."),
     "kneel": ("kneel [beside <target>]", "Kneel down."),
-    "block": ("block", "Block incoming attacks."),
+    "block": ("block", "Raise your guard."),
     "recall": ("recall", "Return to your bind point."),
     "inventory": ("inventory", "View your inventory."),
     "get": ("get <item>\nget <item> from <container>", "Pick up an item."),

--- a/ninjamagic/commands.py
+++ b/ninjamagic/commands.py
@@ -871,7 +871,7 @@ class Help(Command):
         rest = rest.strip().lower()
 
         if not rest:
-            hidden = {*[d.value for d in Compass], "ne", "nw", "se", "sw"}
+            hidden = {*[d.value for d in Compass], "ne", "nw", "se", "sw", "stress"}
             cmd_names = sorted({cmd.text for cmd in commands} - hidden)
             width = max(len(name) for name in cmd_names) + 2
             rows = []

--- a/ninjamagic/commands.py
+++ b/ninjamagic/commands.py
@@ -899,7 +899,8 @@ class Help(Command):
 
         if help_entry := HELP_TEXTS.get(cmd_match.text):
             usage, desc = help_entry
-            text = f"{usage}\n\n  {desc}"
+            usage_lines = "\n".join(f"  {line}" for line in usage.split("\n"))
+            text = f"Usage:\n{usage_lines}\n\n  {desc}"
         else:
             text = f"No help available for '{cmd_match.text}'."
 

--- a/ninjamagic/commands.py
+++ b/ninjamagic/commands.py
@@ -872,8 +872,10 @@ class Help(Command):
         rest = rest.strip().lower()
 
         if not rest:
+            usage, desc = HELP_TEXTS["help"]
+            usage_lines = "\n".join(f"  {line}" for line in usage.split("\n"))
             bus.pulse(
-                bus.Outbound(to=root.source, text=HELP_TEXTS["help"])
+                bus.Outbound(to=root.source, text=f"Usage:\n{usage_lines}\n\n  {desc}")
             )
             return OK
 

--- a/ninjamagic/commands.py
+++ b/ninjamagic/commands.py
@@ -824,7 +824,7 @@ class Recall(Command):
     text: str = "recall"
 
     def trigger(self, root: bus.Inbound) -> Out:
-        to_map_id, to_y, to_x = get_recall(root.source)
+        _, to_map_id, to_y, to_x = get_recall(root.source)
         bus.pulse(
             bus.MovePosition(
                 source=root.source, to_map_id=to_map_id, to_y=to_y, to_x=to_x


### PR DESCRIPTION
## Summary
- `help` - shows help usage, points to `commands`
- `help <command>` - shows help for specific command
- `help help` - easter egg
- `commands` - lists available commands

## Test plan
- [ ] `help` → shows usage
- [ ] `help attack` → shows attack details
- [ ] `help help` → "You need somebody."
- [ ] `commands` → lists all commands

🤖 Generated with [Claude Code](https://claude.com/claude-code)