### PR TITLE
feat: track attacker on FightTimer

### DIFF
--- a/ninjamagic/combat.py
+++ b/ninjamagic/combat.py
@@ -103,6 +103,7 @@ def process(now: Looptime):
 
         source_fight_timer = touch_fight_timer(source, now)
         target_fight_timer = touch_fight_timer(target, now)
+        target_fight_timer.attacker = source
 
         if defense := esper.try_component(target, Defending):
             esper.remove_component(target, Defending)

--- a/ninjamagic/component.py
+++ b/ninjamagic/component.py
@@ -175,11 +175,13 @@ class FightTimer:
     - `last_atk_proc`  used by the procs per minute system to award tokens on attack.
     - `last_def_proc`  used by the procs per minute system to award tokens on defense.
     - `last_refresh`   used to prevent logging out to escape combat.
+    - `attacker`       who is currently attacking this entity.
     """
 
     last_atk_proc: Looptime
     last_def_proc: Looptime
     last_refresh: Looptime
+    attacker: EntityId = 0
 
     def is_active(self) -> bool:
         return get_looptime() - self.last_refresh < settings.fight_timer_len


### PR DESCRIPTION
## Summary
- Add `attacker` field to FightTimer component
- Set attacker on each successful attack in combat.py

This is a foundational change for combat lock mechanics.

## Test plan
- [ ] Attack a mob, verify FightTimer.attacker is set

🤖 Generated with [Claude Code](https://claude.com/claude-code)