### PR TITLE
feat: block movement while being attacked

### DIFF
--- a/ninjamagic/config.py
+++ b/ninjamagic/config.py
@@ -29,6 +29,7 @@ class Settings(BaseSettings):
 
     base_proc_odds: float = 0.10
     fight_timer_len: float = 10.0
+    flee_lag: float = 1.5
 
     model_config = SettingsConfigDict(
         env_nested_delimiter="__", env_file="ninjamagic.env"

--- a/ninjamagic/move.py
+++ b/ninjamagic/move.py
@@ -4,10 +4,15 @@ from ninjamagic import bus
 from ninjamagic.component import (
     Connection,
     ContainedBy,
+    FightTimer,
+    Health,
+    Lag,
     Slot,
     Transform,
     transform,
 )
+from ninjamagic.config import settings
+from ninjamagic.util import get_looptime
 from ninjamagic.world.state import can_enter
 
 
@@ -32,6 +37,19 @@ def process():
             esper.add_component(sig.source, Slot.ANY)
 
     for sig in bus.iter(bus.MoveCompass):
+        # Can't move while being attacked
+        if ft := esper.try_component(sig.source, FightTimer):
+            if ft.is_active() and ft.attacker:
+                attacker_health = esper.try_component(ft.attacker, Health)
+                if attacker_health and attacker_health.condition != "dead":
+                    now = get_looptime()
+                    esper.add_component(sig.source, now + settings.flee_lag, Lag)
+                    if esper.has_component(sig.source, Connection):
+                        bus.pulse(
+                            bus.Outbound(to=sig.source, text="You can't escape!")
+                        )
+                    continue
+
         loc = transform(sig.source)
 
         delta_y, delta_x = sig.dir.to_vector()


### PR DESCRIPTION
## Summary
- Add `flee_lag` config setting (1.5s)
- Block movement in MoveCompass if entity has active FightTimer with living attacker
- Shows "You can't escape!" message and adds lag

Depends on #50

## Test plan
- [ ] Get attacked by mob
- [ ] Try to move - should see "You can't escape!" and be lagged

🤖 Generated with [Claude Code](https://claude.com/claude-code)